### PR TITLE
feat(DEV-521): restyle nft overview page

### DIFF
--- a/apps/web/src/components/FoldableSection/FoldableText.tsx
+++ b/apps/web/src/components/FoldableSection/FoldableText.tsx
@@ -7,6 +7,12 @@ interface FoldableTextProps extends Omit<FlexProps, 'title'> {
   title?: ReactNode
 }
 
+const StyledFlex = styled(Flex)`
+  &:not(:last-child) {
+    border-bottom: 1px solid ${({ theme }) => theme.colors.inputSecondary};
+  }
+`
+
 const Wrapper = styled(Flex)`
   cursor: pointer;
 `
@@ -22,7 +28,6 @@ const StyledChildrenFlex = styled(Flex)<{ isExpanded?: boolean }>`
   overflow: hidden;
   height: ${({ isExpanded }) => (isExpanded ? '100%' : '0px')};
   padding-bottom: ${({ isExpanded }) => (isExpanded ? '16px' : '0px')};
-  border-bottom: 1px solid ${({ theme }) => theme.colors.inputSecondary};
 `
 
 const FoldableText: React.FC<React.PropsWithChildren<FoldableTextProps>> = ({ title, children, ...props }) => {
@@ -30,7 +35,7 @@ const FoldableText: React.FC<React.PropsWithChildren<FoldableTextProps>> = ({ ti
   const [isExpanded, setIsExpanded] = useState(false)
 
   return (
-    <Flex {...props} flexDirection="column">
+    <StyledFlex {...props} flexDirection="column">
       <Wrapper justifyContent="space-between" alignItems="center" pb="16px" onClick={() => setIsExpanded(s => !s)}>
         <Text fontWeight="bold">{title}</Text>
         <StyledExpandableLabelWrapper>
@@ -40,7 +45,7 @@ const FoldableText: React.FC<React.PropsWithChildren<FoldableTextProps>> = ({ ti
       <StyledChildrenFlex isExpanded={isExpanded} flexDirection="column">
         {children}
       </StyledChildrenFlex>
-    </Flex>
+    </StyledFlex>
   )
 }
 

--- a/apps/web/src/components/FoldableSection/SectionsWithFoldableText.tsx
+++ b/apps/web/src/components/FoldableSection/SectionsWithFoldableText.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
-import { Text, Heading, Card, CardHeader, CardBody, Box, BoxProps } from '@verto/uikit'
+import { Text, Heading, Card, CardHeader, CardBody, Box, BoxProps, Container } from '@verto/uikit'
+import { GradientContainer } from 'components/shared/styled'
 import FoldableText from './FoldableText'
 
 interface Props extends BoxProps {
@@ -10,27 +11,31 @@ interface Props extends BoxProps {
 const SectionsWithFoldableText: React.FC<React.PropsWithChildren<Props>> = ({ header, config, ...props }) => {
   return (
     <Box maxWidth="888px" {...props}>
-      <Card>
-        <CardHeader>
-          <Heading scale="lg" color="secondary">
-            {header}
-          </Heading>
-        </CardHeader>
-        <CardBody>
-          {config.map(({ title, description }, i, { length }) => (
-            <FoldableText key={title} id={title} mb={i + 1 === length ? '' : '24px'} title={title}>
-              {description.map((desc, index) => {
-                return (
-                  // eslint-disable-next-line react/no-array-index-key
-                  <Text key={index} color="textSubtle" as="p">
-                    {desc}
-                  </Text>
-                )
-              })}
-            </FoldableText>
-          ))}
-        </CardBody>
-      </Card>
+      <GradientContainer>
+        <Card>
+          <Container padding={['16px', '16px', '24px']}>
+            <CardHeader>
+              <Heading scale="lg" color="secondary">
+                {header}
+              </Heading>
+            </CardHeader>
+            <CardBody>
+              {config.map(({ title, description }, i, { length }) => (
+                <FoldableText key={title} id={title} mb={i + 1 === length ? '' : '16px'} title={title}>
+                  {description.map((desc, index) => {
+                    return (
+                      // eslint-disable-next-line react/no-array-index-key
+                      <Text key={index} color="textSubtle" as="p">
+                        {desc}
+                      </Text>
+                    )
+                  })}
+                </FoldableText>
+              ))}
+            </CardBody>
+          </Container>
+        </Card>
+      </GradientContainer>
     </Box>
   )
 }

--- a/apps/web/src/views/Nft/market/Home/Collections.tsx
+++ b/apps/web/src/views/Nft/market/Home/Collections.tsx
@@ -21,7 +21,7 @@ const Collections: React.FC<React.PropsWithChildren<{ title: string; testId: str
         <Button
           as={NextLinkFromReactRouter}
           to={`${nftsBaseUrl}/collections/`}
-          variant="secondary"
+          variant="vertoCustom"
           minWidth="132px"
           scale="sm"
           endIcon={<ChevronRightIcon color="primary" width="24px" />}>

--- a/apps/web/src/views/Nft/market/Home/Newest.tsx
+++ b/apps/web/src/views/Nft/market/Home/Newest.tsx
@@ -50,7 +50,7 @@ const Newest: React.FC<React.PropsWithChildren> = () => {
         <Button
           as={NextLinkFromReactRouter}
           to={`${nftsBaseUrl}/activity/`}
-          variant="secondary"
+          variant="vertoCustom"
           scale="sm"
           endIcon={<ChevronRightIcon color="primary" />}>
           {t('View All')}
@@ -61,14 +61,15 @@ const Newest: React.FC<React.PropsWithChildren> = () => {
           gridRowGap="24px"
           gridColumnGap="16px"
           gridTemplateColumns={['1fr', 'repeat(2, 1fr)', 'repeat(2, 1fr)', 'repeat(4, 1fr)']}>
-          {nfts.map(nft => {
+          {nfts.map((nft, index) => {
             const isPBCollection = isAddress(nft.collectionAddress) === pancakeBunniesAddress
             const currentAskPrice =
               !isPBCollection && nft.marketData?.isTradable ? parseFloat(nft.marketData?.currentAskPrice) : undefined
             return (
               <CollectibleLinkCard
                 data-test="newest-nft-card"
-                key={nft.collectionAddress + nft.tokenId}
+                // eslint-disable-next-line react/no-array-index-key
+                key={nft.collectionAddress + nft.tokenId + index}
                 nft={nft}
                 currentAskPrice={currentAskPrice}
               />

--- a/apps/web/src/views/Nft/market/Home/index.tsx
+++ b/apps/web/src/views/Nft/market/Home/index.tsx
@@ -1,8 +1,7 @@
 import styled from 'styled-components'
 import {
-  Box,
+  Container,
   Button,
-  Flex,
   Heading,
   LinkExternal,
   PageHeader,
@@ -16,51 +15,22 @@ import { PageMeta } from 'components/Layout/Page'
 import { useGetCollections } from 'state/nftMarket/hooks'
 import { FetchStatus } from 'config/constants/types'
 import PageLoader from 'components/Loader/PageLoader'
-import useTheme from 'hooks/useTheme'
 import orderBy from 'lodash/orderBy'
 import SearchBar from '../components/SearchBar'
 import Collections from './Collections'
 import Newest from './Newest'
 import config from './config'
 
-const Gradient = styled(Box)`
-  background: ${({ theme }) => theme.colors.gradientCardHeader};
-`
-
-const StyledPageHeader = styled(PageHeader)`
-  margin-bottom: -40px;
-  padding-bottom: 40px;
-`
-
-const StyledHeaderInner = styled(Flex)`
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
-  & div:nth-child(1) {
-    order: 1;
-  }
-  & div:nth-child(2) {
-    order: 0;
-    margin-bottom: 32px;
-    align-self: end;
-  }
-  ${({ theme }) => theme.mediaQueries.sm} {
-    flex-direction: row;
-    & div:nth-child(1) {
-      order: 0;
-    }
-    & div:nth-child(2) {
-      order: 1;
-      margin-bottom: 0;
-      align-self: auto;
-    }
-  }
+const StyledSearchBar = styled(SearchBar)`
+  width: 100%;
+  max-width: 650px;
+  margin: 0 auto;
+  padding: 0 24px;
 `
 
 const Home = () => {
   const { t } = useTranslation()
   const { address: account } = useAccount()
-  const { theme } = useTheme()
   const { data: collections, status } = useGetCollections()
 
   const hotCollections = orderBy(
@@ -78,33 +48,27 @@ const Home = () => {
   return (
     <>
       <PageMeta />
-      <StyledPageHeader>
-        <StyledHeaderInner>
-          <div>
-            <Heading as="h1" scale="xxl" color="secondary" mb="24px">
-              {t('NFT Marketplace')}
-            </Heading>
-            <Heading scale="lg" color="text">
-              {t('Buy and Sell NFTs on BNB Smart Chain')}
-            </Heading>
-            {account && (
-              <Button as={NextLinkFromReactRouter} to={`/profile/${account.toLowerCase()}`} mt="32px">
-                {t('Manage/Sell')}
-              </Button>
-            )}
-          </div>
-          <SearchBar />
-        </StyledHeaderInner>
-      </StyledPageHeader>
+      <PageHeader>
+        <Heading as="h1" scale="xxl" color="secondary" mb="24px">
+          {t('NFT Marketplace')}
+        </Heading>
+        <Heading scale="lg" color="text" mb="24px">
+          {t('Buy and Sell NFTs on Rebuschain')}
+        </Heading>
+        {account && (
+          <Button as={NextLinkFromReactRouter} to={`/profile/${account.toLowerCase()}`} mt="32px">
+            {t('Manage/Sell')}
+          </Button>
+        )}
+      </PageHeader>
+      <StyledSearchBar />
       {status !== FetchStatus.Fetched ? (
         <PageLoader />
       ) : (
         <PageSection
-          innerProps={{ style: { margin: '0', width: '100%' } }}
-          background={theme.colors.background}
+          innerProps={{ style: { margin: '0', width: '100%', paddingTop: 0 } }}
           index={1}
-          concaveDivider
-          dividerPosition="top">
+          hasCurvedDivider={false}>
           <Collections
             key="newest-collections"
             title={t('Newest Collections')}
@@ -120,12 +84,12 @@ const Home = () => {
           <Newest />
         </PageSection>
       )}
-      <Gradient p="64px 0">
+      <Container p="64px 0">
         <SectionsWithFoldableText header={t('FAQs')} config={config(t)} m="auto" />
-        <LinkExternal href="https://docs.pancakeswap.finance/contact-us/nft-market-applications" mx="auto" mt="16px">
+        <LinkExternal href="https://docs.pancakeswap.finance/contact-us/nft-market-applications" mx="auto" mt="32px">
           {t('Apply to NFT Marketplace!')}
         </LinkExternal>
-      </Gradient>
+      </Container>
     </>
   )
 }

--- a/apps/web/src/views/Nft/market/components/CollectibleCard/CardBody.tsx
+++ b/apps/web/src/views/Nft/market/components/CollectibleCard/CardBody.tsx
@@ -23,20 +23,20 @@ const CollectibleCardBody: React.FC<React.PropsWithChildren<CollectibleCardProps
   const { isFetching, lowestPrice } = useGetLowestPriceFromNft(nft)
 
   return (
-    <CardBody p="8px">
-      <NFTMedia as={PreviewImage} nft={nft} height={320} width={320} mb="8px" borderRadius="8px" />
-      <Flex alignItems="center" justifyContent="space-between">
+    <CardBody p="0" style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <NFTMedia as={PreviewImage} nft={nft} height={320} width={320} mb="12px" />
+      <Flex alignItems="center" justifyContent="space-between" px="12px" mt="auto">
         {nft?.collectionName && (
-          <Text fontSize="12px" color="textSubtle" mb="8px">
+          <Text fontSize="12px" color="textSubtle">
             {nft?.collectionName}
           </Text>
         )}
         {nftLocation && <LocationTag nftLocation={nftLocation} />}
       </Flex>
-      <Text as="h4" fontWeight="600" mb="8px">
+      <Text as="h4" fontWeight="600" mb="12px" px="12px">
         {name}
       </Text>
-      <Box borderTop="1px solid" borderTopColor="cardBorder" pt="8px">
+      <Box borderTop="1px solid" borderTopColor="cardBorder" p="12px" mt="auto">
         {isPancakeBunny && (
           <LowestPriceMetaRow lowestPrice={lowestPrice} isFetching={isFetching} bnbBusdPrice={bnbBusdPrice} />
         )}

--- a/apps/web/src/views/Nft/market/components/CollectibleCard/CollectibleLinkCard.tsx
+++ b/apps/web/src/views/Nft/market/components/CollectibleCard/CollectibleLinkCard.tsx
@@ -14,7 +14,9 @@ const CollectibleLinkCard: React.FC<React.PropsWithChildren<CollectibleCardProps
   const urlId = isAddress(nft.collectionAddress) === pancakeBunniesAddress ? nft.attributes[0].value : nft.tokenId
   return (
     <StyledCollectibleCard {...props}>
-      <NextLinkFromReactRouter to={`${nftsBaseUrl}/collections/${nft.collectionAddress}/${urlId}`}>
+      <NextLinkFromReactRouter
+        to={`${nftsBaseUrl}/collections/${nft.collectionAddress}/${urlId}`}
+        style={{ height: '100%' }}>
         <CardBody nft={nft} nftLocation={nftLocation} currentAskPrice={currentAskPrice} />
       </NextLinkFromReactRouter>
     </StyledCollectibleCard>

--- a/apps/web/src/views/Nft/market/components/CollectibleCard/CollectionCard.tsx
+++ b/apps/web/src/views/Nft/market/components/CollectibleCard/CollectionCard.tsx
@@ -23,6 +23,8 @@ const StyledCollectionCard = styled(Card)<{ disabled?: boolean }>`
   border-bottom-left-radius: 56px;
   transition: opacity 200ms;
   height: 100%;
+  max-width: 375px;
+  margin: 0 auto;
 
   & > div {
     border: 1px solid ${({ theme }) => theme.colors.cardBorder};

--- a/apps/web/src/views/Nft/market/components/CollectibleCard/PreviewImage.tsx
+++ b/apps/web/src/views/Nft/market/components/CollectibleCard/PreviewImage.tsx
@@ -8,15 +8,7 @@ interface PreviewImageProps extends BoxProps {
 }
 
 const PreviewImage: React.FC<React.PropsWithChildren<PreviewImageProps>> = ({ height = 64, width = 64, ...props }) => {
-  return (
-    <BackgroundImage
-      loadingPlaceholder={<PlaceholderImage />}
-      height={height}
-      width={width}
-      style={{ borderRadius: '8px' }}
-      {...props}
-    />
-  )
+  return <BackgroundImage loadingPlaceholder={<PlaceholderImage />} height={height} width={width} {...props} />
 }
 
 export default PreviewImage

--- a/apps/web/src/views/Nft/market/components/CollectibleCard/styles.tsx
+++ b/apps/web/src/views/Nft/market/components/CollectibleCard/styles.tsx
@@ -123,12 +123,13 @@ export const SellingNftTag: React.FC<React.PropsWithChildren<NftTagProps>> = pro
 }
 
 export const StyledCollectibleCard = styled(Card)`
-  border-radius: 8px;
+  border-radius: 20px;
+  border: 1px solid ${({ theme }) => theme.colors.cardBorder};
   max-width: 320px;
   transition: opacity 200ms;
 
   & > div {
-    border-radius: 8px;
+    border-radius: 20px;
   }
 
   ${({ theme }) => theme.mediaQueries.lg} {

--- a/apps/web/src/views/Nft/market/components/NFTMedia.tsx
+++ b/apps/web/src/views/Nft/market/components/NFTMedia.tsx
@@ -1,4 +1,4 @@
-import { Box, BoxProps } from '@verto/uikit'
+import { Box, BoxProps, Image } from '@verto/uikit'
 import { FC, useEffect, useRef } from 'react'
 import { useIntersectionObserver } from '@verto/hooks'
 import { NftToken } from 'state/nftMarket/types'
@@ -6,11 +6,18 @@ import styled from 'styled-components'
 import { useTryVideoNftMedia } from 'state/nftMarket/hooks'
 import { useAppDispatch } from 'state'
 import { useNftStorage } from 'state/nftMarket/storage'
-import { RoundedImage } from '../Collection/IndividualNFTPage/shared/styles'
 
 const StyledAspectRatio = styled(Box)`
   position: absolute;
   inset: 0;
+`
+
+export const NftMediaImage = styled(Image)`
+  height: max-content;
+  overflow: hidden;
+  & > img {
+    object-fit: contain;
+  }
 `
 
 export const AspectRatio = ({ ratio, children, ...props }) => (
@@ -62,7 +69,7 @@ const NFTMedia: FC<
   }
 
   return (
-    <RoundedImage
+    <NftMediaImage
       width={width}
       height={height}
       src={nft?.image.gif || nft?.image.thumbnail}

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -1200,7 +1200,7 @@
   "No NFTs found": "No NFTs found",
   "Listed": "Listed",
   "Transaction Details": "Transaction Details",
-  "Buy and Sell NFTs on BNB Smart Chain": "Buy and Sell NFTs on BNB Smart Chain",
+  "Buy and Sell NFTs on Rebuschain": "Buy and Sell NFTs on Rebuschain",
   "Modified": "Modified",
   "From/To": "From/To",
   "Item": "Item",


### PR DESCRIPTION
Restyling the NFT overview page:
<img width="1241" alt="Screenshot 2023-03-08 at 5 56 42 PM" src="https://user-images.githubusercontent.com/121128135/223896023-1523f1cb-dfb7-4ec7-8c91-e86be99a842f.png">
<img width="1337" alt="Screenshot 2023-03-08 at 5 56 54 PM" src="https://user-images.githubusercontent.com/121128135/223896070-be1a7216-7dd2-422e-bac4-e451d5ff7743.png">
<img width="1268" alt="Screenshot 2023-03-08 at 5 57 17 PM" src="https://user-images.githubusercontent.com/121128135/223896076-024530bf-1f7c-49b7-adff-ec1f4357a20d.png">
<img width="1092" alt="Screenshot 2023-03-08 at 5 57 25 PM" src="https://user-images.githubusercontent.com/121128135/223896080-9909e5ca-ea0b-473f-8d65-20481cd69590.png">
