### PR TITLE
Dev 513 - Added functionality to deploy to prod / and deploy previouse builds.

### DIFF
--- a/.github/workflows/action-build-backend.yml
+++ b/.github/workflows/action-build-backend.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Checkout 🛎️
         # Checkout code from repository
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         # Installs and sets up Docker Buildx

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout 🛎️
         # Checkout code from repository
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
 
       - name: Cache node modules
         # Restores the build from cache to speed up build process

--- a/.github/workflows/action-deploy-ecs.yml
+++ b/.github/workflows/action-deploy-ecs.yml
@@ -34,6 +34,12 @@ on:
       task_execution_role_arn:
         required: true
         type: string
+      container_definitions_image:
+        required: true
+        type: string
+      family:
+        required: true
+        type: string
     secrets:
       aws_access_key_id:
         required: true
@@ -45,7 +51,7 @@ jobs:
     steps:
       - name: Checkout 🛎️
         # Checkout the code repository
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
 
       - name: Configure AWS credentials
         id: configure-aws-credentials
@@ -74,22 +80,23 @@ jobs:
           echo "${{needs.publish.outputs.image_name}}"
 
       - name: Replace task definition values
-        # Replace the values
-        id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition: ${{ inputs.task_definition }}
-          container-name: ${{ inputs.container_name }}
-          # Retreive from step above(get-img)
-          image: ${{ steps.get-img.outputs.image }}
-          environment-variables: |
-            APP_ENV=${{ inputs.env }}
+        shell: bash
+        run: |
+            export APP_ENV=${{ inputs.env }}
+            export FAMILY=${{ inputs.family }}
+            export TASK_ROLE_ARN=${{ inputs.task_role_arn }}
+            export EXECUTION_ROLE_ARN=${{ inputs.task_execution_role_arn }}
+            export CONTAINER_DEFINITIONS_IMAGE=${{ inputs.container_definitions_image }}
+            export AWS_LOGS_GROUP=${{ inputs.aws_log_group }}
+            export AWS_LOGS_REGION=${{ inputs.aws_region }}
+            envsubst < ${{ inputs.task_definition }} > taskdefinition.json
+            cat taskdefinition.json
 
       - name: Deploy Amazon ECS task definition
         # Deploy to ECS
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
-          task-definition: ${{ inputs.task_definition }}
+          task-definition: taskdefinition.json
           service: ${{ inputs.service }}
           cluster: ${{ inputs.cluster }}
           wait-for-service-stability: true

--- a/.github/workflows/action-deploy-s3.yml
+++ b/.github/workflows/action-deploy-s3.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Checkout 🛎️
         # Checkout the code repository
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
 
       - name: Restore build from cache
         # Restores the build from cache to speed up build process
@@ -87,5 +87,5 @@ jobs:
           aws_access_key_id: ${{ secrets.aws_access_key_id }}
           aws_secret_access_key: ${{ secrets.aws_secret_access_key }}
           source: ./build
-          dest: s3://verto-dev-assets/${{ github.ref_name }}
+          dest: s3://${{ secrets.asset_bucket }}/${{ github.ref_name }}
           flags: --recursive

--- a/.github/workflows/action-install-lint.yml
+++ b/.github/workflows/action-install-lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
 
       - name: Cache node modules
        # Restores the build from cache to speed up build process
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Checkout 🛎️
           # Checkout the code repository
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
 
       - name: Cache node modules
         # Restores the build from cache to speed up build process

--- a/.github/workflows/action-push-ecr-image.yml
+++ b/.github/workflows/action-push-ecr-image.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Checkout 🛎️
         # Checkout the code repository
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         # Set up Docker Buildx

--- a/.github/workflows/deploy-dev-prod.yml
+++ b/.github/workflows/deploy-dev-prod.yml
@@ -1,0 +1,141 @@
+name: Deploys to Dev and Prod
+on:
+  # Trigger the workflow on push to the main branch
+  push:
+    branches:
+      - main
+  repository_dispatch:
+    types: [dev]
+  # Trigger the workflow on workflow dispatch
+  workflow_dispatch:
+# Environment variables required for deployment
+env:
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: verto-dev-ui-nginx
+  ECS_SERVICE: verto-dev-ui-nginx
+  ECS_CLUSTER: verto-dev-ui-ecs-fargate
+  ECS_TASK_DEFINITION: ./apps/web/task-definition.json
+  CONTAINER_NAME: nginx
+  ASSETS_BUCKET: verto-dev-assets
+  # Concurrency for the workflow
+concurrency:
+  group: dev
+  cancel-in-progress: true
+
+jobs:
+  # Job to install dependencies and run lint checks
+  install-and-lint:
+    uses: vertotrade/verto.ui/.github/workflows/action-install-lint.yml@main
+
+  # Job to build the UI/Next.js
+  build:
+    uses: vertotrade/verto.ui/.github/workflows/action-build.yml@main
+    needs: [install-and-lint]
+    # Passes the environment variable "env" with value "dev" to the action
+    with:
+      env: dev
+
+  # Job to build the backend/Docker
+  be-build:
+    uses: vertotrade/verto.ui/.github/workflows/action-build-backend.yml@main
+    needs: [build]
+    with:
+      ecr_repo: verto-dev-ui-nginx
+
+  # Job to publish the built backend/Docker image to ECR
+  be-publish-dev:
+    uses: vertotrade/verto.ui/.github/workflows/action-push-ecr-image.yml@main
+    needs: [be-build]
+    # Passes the environment variables "aws_region", "build_number", and "ecr_repo" to the action
+    with:
+      aws_region: us-east-1
+      build_number: ${{ github.run_id }}
+      ecr_repo: verto-dev-ui-nginx
+      # Secrets required
+    secrets:
+      aws_access_key_id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
+
+  # This job deploys the backend using AWS ECS
+  be-deploy-dev:
+    uses: vertotrade/verto.ui/.github/workflows/action-deploy-ecs.yml@main
+    needs: [be-publish-dev]
+    # The following inputs are passed to the AWS ECS deployment action
+    with:
+      env: dev
+      task_definition: ./apps/web/task-definition.json
+      family: verto-dev-ui-nginx
+      task_role_arn: arn:aws:iam::073696056884:role/rebus-mainnet-ecs-task-role
+      task_execution_role_arn: arn:aws:iam::073696056884:role/rebus-mainnet-ecs-task-execution-role
+      container_name: nginx
+      container_definitions_image: 073696056884.dkr.ecr.us-east-1.amazonaws.com/verto-dev-ui-nginx:latest
+      aws_log_group: /verto/ecs/dev/ui-nginx
+      aws_region: us-east-1
+      ecr_repo: verto-dev-ui-nginx
+      service: verto-dev-ui-nginx
+      cluster: verto-dev-ui-ecs-fargate
+    secrets:
+      aws_access_key_id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
+
+  # This job deploys to teh assets bucket of the project
+  fe-deploy-dev:
+    uses: vertotrade/verto.ui/.github/workflows/action-deploy-s3.yml@main
+    # This job needs the frontend environment to be built
+    # Will run simunteniously with be-build
+    needs: [build]
+    with:
+      env: dev
+      type: main
+      aws_region: us-east-1
+    secrets:
+      aws_access_key_id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
+      asset_bucket: verto-dev-assets
+
+  # Prod deployments
+  pre-prod-push-check:
+    runs-on: ubuntu-latest
+    needs: [be-deploy-dev, fe-deploy-dev]
+    environment: provision.prod
+    steps:
+      - name: Pre Prod push check
+        run: echo "Review to deploy to Prod"
+
+  # This job deploys the backend using AWS ECS
+  be-deploy-prod:
+    uses: vertotrade/verto.ui/.github/workflows/action-deploy-ecs.yml@main
+    needs: [pre-prod-push-check]
+    # The following inputs are passed to the AWS ECS deployment action
+    with:
+      env: prod
+      task_definition: ./apps/web/task-definition.json
+      family: verto-prod-ui-nginx
+      task_role_arn: arn:aws:iam::073696056884:role/rebus-mainnet-ecs-task-role
+      task_execution_role_arn: arn:aws:iam::073696056884:role/rebus-mainnet-ecs-task-execution-role
+      container_name: nginx
+      container_definitions_image: 073696056884.dkr.ecr.us-east-1.amazonaws.com/verto-prod-ui-nginx:latest
+      aws_log_group: /verto/ecs/prod/ui-nginx
+      aws_region: us-east-1
+      ecr_repo: verto-prod-ui-nginx
+      service: verto-prod-ui-nginx
+      cluster: verto-prod-ui-ecs-fargate
+    secrets:
+      aws_access_key_id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
+
+  # This job deploys to teh assets bucket of the project
+  fe-deploy-prod:
+    uses:
+      vertotrade/verto.ui/.github/workflows/action-deploy-s3.yml@main
+      # This job needs the frontend environment to be built
+      # Will run simunteniously with be-build
+    needs: [pre-prod-push-check]
+    with:
+      env: prod
+      type: main
+      aws_region: us-east-1
+    secrets:
+      aws_access_key_id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
+      asset_bucket: verto-prod-assets

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,9 +1,5 @@
 name: Deploys to Dev
 on:
-  # Trigger the workflow on push to the main branch
-  push:
-    branches:
-      - main
   repository_dispatch:
     types:
       [dev]
@@ -15,7 +11,7 @@ env:
   ECR_REPOSITORY: verto-dev-ui-nginx
   ECS_SERVICE: verto-dev-ui-nginx
   ECS_CLUSTER: verto-dev-ui-ecs-fargate
-  ECS_TASK_DEFINITION: ./apps/web/task-definition.json
+  ECS_TASK_DEFINITION: ./apps/web/task-definition-dev.json
   CONTAINER_NAME: nginx
   ASSETS_BUCKET: verto-dev-assets
   # Concurrency for the workflow
@@ -54,8 +50,8 @@ jobs:
       ecr_repo: verto-dev-ui-nginx
       # Secrets required
     secrets:
-      aws_access_key_id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
+      aws_access_key_id: ${{ secrets.VERTO_AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.VERTO_AWS_SECRET_ACCESS_KEY }}
 
   # This job deploys the backend using AWS ECS
   be-deploy-dev:
@@ -64,7 +60,7 @@ jobs:
     # The following inputs are passed to the AWS ECS deployment action
     with:
       env: dev
-      task_definition: ./apps/web/task-definition.json
+      task_definition: ./apps/web/task-definition-dev.json
       aws_region: us-east-1
       ecr_repo: verto-dev-ui-nginx
       service: verto-dev-ui-nginx
@@ -74,8 +70,8 @@ jobs:
       task_execution_role_arn: arn:aws:iam::073696056884:role/rebus-mainnet-ecs-task-execution-role
       container_name: nginx
     secrets:
-      aws_access_key_id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
+      aws_access_key_id: ${{ secrets.VERTO_AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.VERTO_AWS_SECRET_ACCESS_KEY }}
 
   # This job deploys to teh assets bucket of the project
   fe-deploy-dev:
@@ -88,6 +84,6 @@ jobs:
       type: main
       aws_region: us-east-1
     secrets:
-      aws_access_key_id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
+      aws_access_key_id: ${{ secrets.VERTO_AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.VERTO_AWS_SECRET_ACCESS_KEY }}
       asset_bucket: verto-dev-assets

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -7,7 +7,7 @@ concurrency:
 
 jobs:
   # Job to install dependencies and run lint checks
-  install-lint:
+  install-and-lint:
     uses: vertotrade/verto.ui/.github/workflows/action-install-lint.yml@main
 
   # Job to build the UI/Next.js
@@ -34,8 +34,8 @@ jobs:
       build_number: ${{ github.run_id }}
       ecr_repo: verto-prod-ui-nginx
     secrets:
-      aws_access_key_id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+      aws_access_key_id: ${{ secrets.VERTO_AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.VERTO_AWS_SECRET_ACCESS_KEY }}
 
   # This job deploys the backend using AWS ECS
   be-deploy-prod:
@@ -45,16 +45,19 @@ jobs:
     with:
       env: prod
       task_definition: ./apps/web/task-definition.json
+      family: verto-prod-ui-nginx
+      task_role_arn: arn:aws:iam::073696056884:role/rebus-mainnet-ecs-task-role
+      task_execution_role_arn: arn:aws:iam::073696056884:role/rebus-mainnet-ecs-task-execution-role
+      container_name: nginx
+      container_definitions_image: 073696056884.dkr.ecr.us-east-1.amazonaws.com/verto-prod-ui-nginx:latest
+      aws_log_group: /verto/ecs/prod/ui-nginx
       aws_region: us-east-1
       ecr_repo: verto-prod-ui-nginx
       service: verto-prod-ui-nginx
       cluster: verto-prod-ui-ecs-fargate
-      aws_log_group: /verto/ecs/prod/ui-nginx
-      task_role_arn: arn:aws:iam::517696922803:role/dropmint-prod-ecs-task-role
-      task_execution_role_arn: arn:aws:iam::517696922803:role/dropmint-prod-ecs-task-execution-role
     secrets:
-      aws_access_key_id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+      aws_access_key_id: ${{ secrets.VERTO_AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.VERTO_AWS_SECRET_ACCESS_KEY }}
 
   # This job deploys to teh assets bucket of the project
   fe-deploy-prod:
@@ -68,7 +71,7 @@ jobs:
       type: main
       aws_region: us-east-1
     secrets:
-      aws_access_key_id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+      aws_access_key_id: ${{ secrets.VERTO_AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.VERTO_AWS_SECRET_ACCESS_KEY }}
       asset_bucket: verto-prod-assets
-      cloudfront_id: ${{ secrets.PROD_CLOUDFRONT_ID }}
+      cloudfront_id: ${{ secrets.VERTO_CLOUDFRONT_ID }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/apps/web/task-definition-dev.json
+++ b/apps/web/task-definition-dev.json
@@ -1,15 +1,15 @@
 {
-  "family": "${FAMILY}",
-  "taskRoleArn": "${TASK_ROLE_ARN}",
-  "executionRoleArn": "${EXECUTION_ROLE_ARN}",
+  "family": "verto-dev-ui-nginx",
+  "taskRoleArn": "arn:aws:iam::073696056884:role/rebus-mainnet-ecs-task-role",
+  "executionRoleArn": "arn:aws:iam::073696056884:role/rebus-mainnet-ecs-task-execution-role",
   "networkMode": "awsvpc",
   "requiresCompatibilities": ["FARGATE"],
   "cpu": "512",
   "memory": "1024",
   "containerDefinitions": [
     {
-      "name":  "nginx",
-      "image": "${CONTAINER_DEFINITIONS_IMAGE}",
+      "name": "nginx",
+      "image": "073696056884.dkr.ecr.us-east-1.amazonaws.com/verto-dev-ui-nginx:latest",
       "portMappings": [
         {
           "containerPort": 3000,
@@ -27,9 +27,9 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "${AWS_LOGS_GROUP}",
-          "awslogs-region": "${AWS_LOGS_REGION}",
-          "awslogs-stream-prefix": "${APP_ENV}"
+          "awslogs-group": "/verto/ecs/dev/ui-nginx",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "dev"
         }
       }
     }


### PR DESCRIPTION
Added a pipeline to prod. Currently, it is prod.vertotrade.com, but when it's ready to go live, it will be switched to vertotrade.com. Due to changed requirements in the ticket, dev.vertotrade.com will remain on the mainnet, and prod will run also on the mainnet. Both will use the same load balancer.