### PR TITLE
add expires and no cache meta tags

### DIFF
--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -84,6 +84,10 @@ function MyApp(props: AppProps<{ initialReduxState: any }>) {
           content="Verto D.exchange. Where DeFi, Metaverse, P2E and TradFi meet to create the future of Fintech."
         />
 
+        <meta httpEquiv="Cache-Control" content="no-store, no-cache, must-revalidate" />
+        <meta httpEquiv="Pragma" content="no-cache" />
+        <meta httpEquiv="Expires" content="0" />
+
         <title>VertoTrade - D.exchange</title>
         {/* removed since it is not needed for Rebuschain
         (Component as NextPageWithLayout).mp && (


### PR DESCRIPTION
This pull request adds the cache-control and expires meta tags to the <Head> section in order to prevent the browser from caching the source of the page.