### PR TITLE
Dev 721 updated size of vcoin animation

### DIFF
--- a/apps/web/src/components/Clip.tsx
+++ b/apps/web/src/components/Clip.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 
-export function Clip({ url }) {
+export function Clip({ url, width = '100%', height = '100%' }) {
   const videoRef = useRef<HTMLVideoElement | null>(null)
 
   useEffect(() => {
@@ -14,7 +14,7 @@ export function Clip({ url }) {
   }, [url])
 
   return (
-    <video width="100%" height="100%" autoPlay muted loop ref={videoRef}>
+    <video width={width} height={height} autoPlay muted loop ref={videoRef}>
       <source src={url} />
     </video>
   )

--- a/apps/web/src/components/IconDivider/index.tsx
+++ b/apps/web/src/components/IconDivider/index.tsx
@@ -15,7 +15,7 @@ const IconDiv = styled(Flex)`
 `
 const IconDivReverse = styled(Flex)`
   min-width: 595px;
-  border-radius: 140px 0px 0px 140px;
+  border-radius: 176px 0px 0px 176px;
   background: ${props => props.background};
   justify-content: flex-start;
   flex-grow: 1;
@@ -27,8 +27,8 @@ const IconDivReverse = styled(Flex)`
 `
 
 const IconCircleWrapper = styled(Flex)`
-  width: 220px;
-  height: 220px;
+  width: 256px;
+  height: 256px;
   border-radius: 50%;
   justify-content: center;
   align-items: center;

--- a/apps/web/src/components/IconDivider/index.tsx
+++ b/apps/web/src/components/IconDivider/index.tsx
@@ -27,6 +27,14 @@ const IconDivReverse = styled(Flex)`
 `
 
 const IconCircleWrapper = styled(Flex)`
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  justify-content: center;
+  align-items: center;
+  background: ${props => props.background};
+`
+const IconCircleWrapperVCoinAnim = styled(Flex)`
   width: 256px;
   height: 256px;
   border-radius: 50%;
@@ -41,15 +49,19 @@ const IconImgWrapper = styled(Flex)`
 
 const IconDivider = ({ background, textColor, divBackground, Icon = CoinStack, reverse = false, Clip = null }) => {
   const InnerContent = (
-    <IconCircleWrapper background={background}>
+    <>
       {Clip ? (
-        <Clip />
+        <IconCircleWrapperVCoinAnim>
+          <Clip />
+        </IconCircleWrapperVCoinAnim>
       ) : (
-        <IconImgWrapper>
-          <Icon color={textColor} />
-        </IconImgWrapper>
+        <IconCircleWrapper background={background}>
+          <IconImgWrapper>
+            <Icon color={textColor} />
+          </IconImgWrapper>
+        </IconCircleWrapper>
       )}
-    </IconCircleWrapper>
+    </>
   )
   return (
     <>

--- a/apps/web/src/views/Home/components/SalesSection/data.tsx
+++ b/apps/web/src/views/Home/components/SalesSection/data.tsx
@@ -88,7 +88,7 @@ export const vertoSectionData = (t: TranslateFunction, isDark: boolean, theme: a
       background="transparent"
       textColor={isDark ? theme.colors.text : theme.colors.black}
       divBackground={theme.colors.backgroundAlt}
-      Clip={() => <Clip url="images/animations/token.webm" />}
+      Clip={() => <Clip url="images/animations/token.webm" width="256px" height="256px" />}
       reverse
     />
   ),


### PR DESCRIPTION
Updated size of vcoin animation from 220x220 to 256x256.

Before:
<img width="1557" alt="Update size of vcoin animation - 220x220" src="https://github.com/vertotrade/verto.ui/assets/150782162/ecdf4652-98ee-4fdc-ade3-17b6437b282e">

After:
<img width="1557" alt="Update size of vcoin animation - 256x256" src="https://github.com/vertotrade/verto.ui/assets/150782162/774dc854-330a-47df-971d-f76e636f4b57">



Note: height and width were set to 100% to its parent. Its parent element had the height and width set to 220px instead of 180px