### PR TITLE
remove hover color from all footer links

### DIFF
--- a/packages/uikit/src/components/Footer/Footer.tsx
+++ b/packages/uikit/src/components/Footer/Footer.tsx
@@ -69,6 +69,7 @@ const MenuItem: React.FC<React.PropsWithChildren<FooterProps>> = ({
                       color="text"
                       bold={false}
                       internal={internal}
+                      hoverBackgroundColor = "inherit"
                     >
                       {label}
                     </Link>


### PR DESCRIPTION
Remove hover color from all footer links
Before: 
<img width="330" alt="Screenshot 2023-11-23 at 4 44 54 PM" src="https://github.com/vertotrade/verto.ui/assets/150782162/49d69586-bb70-470a-9759-78b73486dfa8">
After

https://github.com/vertotrade/verto.ui/assets/150782162/b0bd9675-b323-48a4-90b0-cd7d0f975c7c

