### PR TITLE
remove background color from social links in footer section

### DIFF
--- a/packages/uikit/src/components/Footer/Components/SocialLinks.tsx
+++ b/packages/uikit/src/components/Footer/Components/SocialLinks.tsx
@@ -31,7 +31,7 @@ const SocialLinks: React.FC<React.PropsWithChildren<FlexProps>> = ({ ...props })
       const mr = index < socials.length - 1 ? "24px" : 0;
 
       return (
-        <SocialLink external key={social.label} href={social.href} aria-label={social.label} mr={mr}>
+        <SocialLink external key={social.label} href={social.href} aria-label={social.label} mr={mr} hoverBackgroundColor="inherit">
           <Icon {...iconProps} />
         </SocialLink>
       );


### PR DESCRIPTION
Remove background color from social links
Before:
<img width="224" alt="Screenshot 2023-11-23 at 4 47 05 PM" src="https://github.com/vertotrade/verto.ui/assets/150782162/1b73d67f-fb03-47d0-ab99-6100537ff011">
After:

https://github.com/vertotrade/verto.ui/assets/150782162/a9d28bb3-b39d-4265-aea4-f34d19b3dc0c


