### PR TITLE
remove scroll up button for mobile view

### DIFF
--- a/packages/uikit/src/components/ScrollToTopButton/ScrollToTopButtonV2.tsx
+++ b/packages/uikit/src/components/ScrollToTopButton/ScrollToTopButtonV2.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import throttle from "lodash/throttle";
 import { Button } from "../Button";
 import { ArrowUpIcon } from "../Svg";
+import { useMatchBreakpoints } from "../../contexts";
 
 const FixedContainer = styled.div`
   position: fixed;
@@ -12,6 +13,7 @@ const FixedContainer = styled.div`
 
 const ScrollToTopButtonV2 = () => {
   const [visible, setVisible] = useState(false);
+  const { isMobile } = useMatchBreakpoints();
 
   const scrollToTop = useCallback(() => {
     window.scrollTo({
@@ -38,7 +40,7 @@ const ScrollToTopButtonV2 = () => {
   }, []);
 
   return (
-    <FixedContainer style={{ display: visible ? "inline" : "none" }}>
+    <FixedContainer style={{ display: visible && !isMobile ? "inline" : "none" }}>
       <Button
         width={48}
         height={48}


### PR DESCRIPTION
Remove scroll up button for mobile view
Before: 
<img width="160" alt="Screenshot 2023-11-24 at 12 53 39 PM" src="https://github.com/vertotrade/verto.ui/assets/150782162/a60dea9f-d7dc-4890-a6a4-3fc256b6e6d8">
After:
<img width="336" alt="Screenshot 2023-11-24 at 12 52 50 PM" src="https://github.com/vertotrade/verto.ui/assets/150782162/5da9fd6b-cf20-4656-a5b2-4e2d0e759106">
