### PR TITLE
Resize the first heading in hero section

### DIFF
--- a/apps/web/src/views/Home/components/ColoredWordHeading.tsx
+++ b/apps/web/src/views/Home/components/ColoredWordHeading.tsx
@@ -5,11 +5,13 @@ import useTheme from 'hooks/useTheme'
 interface HeadingProps extends TextProps {
   text: string
   firstColor?: keyof Colors
+  style?: React.CSSProperties
 }
 
 const ColoredWordHeading: React.FC<React.PropsWithChildren<HeadingProps>> = ({
   text,
   firstColor,
+  style,
   mb = '24px',
   ...props
 }) => {
@@ -23,7 +25,7 @@ const ColoredWordHeading: React.FC<React.PropsWithChildren<HeadingProps>> = ({
   const displayedColor = (theme.colors[firstColor] as string) ?? theme.colors.textHome
 
   return (
-    <Heading scale="xxl" mb={mb} style={{ fontWeight: 800, maxWidth: '503px' }} {...props}>
+    <Heading scale="xxl" mb={mb} style={{ fontWeight: 800, maxWidth: '503px', ...(style || {}) }} {...props}>
       <span style={{ color: displayedColor }}>{firstWord} </span>
       {remainingWords}
     </Heading>

--- a/apps/web/src/views/Home/components/SalesSection/data.tsx
+++ b/apps/web/src/views/Home/components/SalesSection/data.tsx
@@ -5,6 +5,7 @@ import { SalesSectionProps } from '.'
 
 export const swapSectionData = (t: TranslateFunction, isDark: boolean): SalesSectionProps => ({
   headingText: t('Trade smarter, not harder.'),
+  headingStyle: { fontSize: '64px', lineHeight: '72px' },
   bodyText: t('Trade any token on Rebuschain in seconds, just by connecting your wallet.'),
   reverse: false,
   primaryButton: {

--- a/apps/web/src/views/Home/components/SalesSection/index.tsx
+++ b/apps/web/src/views/Home/components/SalesSection/index.tsx
@@ -67,6 +67,7 @@ export interface SalesSectionProps {
   colorOverride?: boolean
   ClipComponent?: React.ComponentType
   addContainerStyles?: boolean
+  headingStyle?: React.CSSProperties
 }
 
 const SalesSection: React.FC<React.PropsWithChildren<SalesSectionProps>> = props => {
@@ -96,7 +97,12 @@ const SalesSection: React.FC<React.PropsWithChildren<SalesSectionProps>> = props
             ml={[null, null, null, reverse && '64px']}
             mr={[null, null, null, !reverse && '64px']}
             alignSelf={['flex-start', null, null, 'flex-start']}>
-            <ColoredWordHeading text={headingText} firstColor="text" color={theme.colors.text} />
+            <ColoredWordHeading
+              text={headingText}
+              style={props.headingStyle}
+              firstColor="text"
+              color={theme.colors.text}
+            />
             <Text color={theme.colors.text} mb="24px">
               {bodyText}
             </Text>


### PR DESCRIPTION
Resized the first heading in hero section.

Before:
![image](https://github.com/vertotrade/verto.ui/assets/150782162/2da82918-d48a-4563-b282-4c5625b1411e)


After:
![image](https://github.com/vertotrade/verto.ui/assets/150782162/281b5504-b8cd-4181-abd9-87c3fe2cc6f7)
