### PR TITLE
remove scroll up button for mobile view

### DIFF
--- a/packages/uikit/src/components/ScrollToTopButton/ScrollToTopButtonV2.tsx
+++ b/packages/uikit/src/components/ScrollToTopButton/ScrollToTopButtonV2.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import throttle from "lodash/throttle";
 import { Button } from "../Button";
 import { ArrowUpIcon } from "../Svg";
+import { useMatchBreakpoints } from "../../contexts";
 
 const FixedContainer = styled.div`
   position: fixed;
@@ -12,6 +13,7 @@ const FixedContainer = styled.div`
 
 const ScrollToTopButtonV2 = () => {
   const [visible, setVisible] = useState(false);
+  const { isMobile } = useMatchBreakpoints();
 
   const scrollToTop = useCallback(() => {
     window.scrollTo({
@@ -38,7 +40,7 @@ const ScrollToTopButtonV2 = () => {
   }, []);
 
   return (
-    <FixedContainer style={{ display: visible ? "inline" : "none" }}>
+    <FixedContainer style={{ display: visible && !isMobile ? "inline" : "none" }}>
       <Button
         width={48}
         height={48}


### PR DESCRIPTION
Remove scroll up button for mobile view
Before:
![image](https://github.com/vertotrade/verto.ui/assets/150782162/a42eec36-e759-46fd-8d99-72034578d2ee)

After:
![image](https://github.com/vertotrade/verto.ui/assets/150782162/92587e30-2a70-46f8-990c-4b00e14d68ec)
