### PR TITLE
update all the navigation dropdowns background and opacity

### DIFF
--- a/packages/uikit/src/components/DropdownMenu/styles.tsx
+++ b/packages/uikit/src/components/DropdownMenu/styles.tsx
@@ -36,7 +36,8 @@ export const DropdownMenuItem = styled.button<StyledDropdownMenuItemProps & { $i
   }
 
   &:hover:not(:disabled) {
-    background-color: ${({ theme }) => theme.colors.tertiary};
+    background-color: ${({ theme }) => theme.colors.vertoBg1};
+    border-radius: 5px;
   }
 
   &:active:not(:disabled) {
@@ -46,15 +47,8 @@ export const DropdownMenuItem = styled.button<StyledDropdownMenuItemProps & { $i
 `;
 
 export const StyledDropdownMenuItemContainer = styled.div`
-  &:first-child ${DropdownMenuItem} {
-    border-top-left-radius: 8px;
-    border-top-right-radius: 8px;
-  }
-
-  &:last-child ${DropdownMenuItem} {
-    border-bottom-left-radius: 8px;
-    border-bottom-right-radius: 8px;
-  }
+  margin: 8px 12px;
+  border-radius: 5px;
 `;
 
 export const DropdownMenuDivider = styled.hr`


### PR DESCRIPTION
Update navigation dropdowns
Before:
![image](https://github.com/vertotrade/verto.ui/assets/150782162/817edc73-e0a1-47a6-8dd7-65b3b3d52eb0)
After:

https://github.com/vertotrade/verto.ui/assets/150782162/764bd9d6-a54e-4301-bafa-ebbea5fc0c8d

