### PR TITLE
remove hover color from all footer links

### DIFF
--- a/packages/uikit/src/components/Footer/Footer.tsx
+++ b/packages/uikit/src/components/Footer/Footer.tsx
@@ -69,6 +69,7 @@ const MenuItem: React.FC<React.PropsWithChildren<FooterProps>> = ({
                       color="text"
                       bold={false}
                       internal={internal}
+                      hoverBackgroundColor = "inherit"
                     >
                       {label}
                     </Link>


### PR DESCRIPTION
Remove hover color from all footer links
Before:
![image](https://github.com/vertotrade/verto.ui/assets/150782162/1cbe9db7-fecc-4707-a46f-6dd14828c53a)
After:

https://github.com/vertotrade/verto.ui/assets/150782162/a52d90bf-baf7-4e25-a321-2f2408c4c1bd

