### PR TITLE
Removed underlining for learn more buttons

### DIFF
--- a/apps/web/src/views/Home/components/SalesSection/index.tsx
+++ b/apps/web/src/views/Home/components/SalesSection/index.tsx
@@ -117,7 +117,11 @@ const SalesSection: React.FC<React.PropsWithChildren<SalesSectionProps>> = props
                 )}
               </Button>
               {secondaryButton.external ? (
-                <LinkExternal color={theme.colors.text} href={secondaryButton.to} padding="0 20px">
+                <LinkExternal
+                  color={theme.colors.text}
+                  textDecoration="none"
+                  href={secondaryButton.to}
+                  padding="0 20px">
                   {secondaryButton.text}
                 </LinkExternal>
               ) : (

--- a/apps/web/src/views/Home/index.tsx
+++ b/apps/web/src/views/Home/index.tsx
@@ -172,6 +172,7 @@ const Home: React.FC<React.PropsWithChildren> = () => {
                   style={{ marginTop: '20px' }}
                   color="black"
                   padding="0 20px"
+                  textDecoration="none"
                   hoverBackgroundColor={theme.isDark ? 'white' : theme.colors.secondaryButtonHoverBg}
                   external
                   href="https://docs.vertotrade.com/">

--- a/packages/uikit/src/components/Link/Link.tsx
+++ b/packages/uikit/src/components/Link/Link.tsx
@@ -11,8 +11,10 @@ const StyledLink = styled(Text)<LinkProps>`
   width: fit-content;
   padding: ${(props) => props.padding || `0`};
   border-radius: 25px;
+  -webkit-transition: background-color 0.2s, opacity 0.2s;
+  transition: background-color 0.2s, opacity 0.2s;
   &:hover {
-    text-decoration: underline;
+    text-decoration: ${(props) => props.textDecoration};
     background-color: ${(props) => props.hoverBackgroundColor || props.theme.colors.secondaryButtonHoverBg};
   }
   &:active {
@@ -28,6 +30,7 @@ const Link: React.FC<React.PropsWithChildren<LinkProps>> = ({ external, internal
 /* eslint-disable react/default-props-match-prop-types */
 Link.defaultProps = {
   color: "primary",
+  textDecoration: "underline",
 };
 
 export default Link;

--- a/packages/uikit/src/components/Link/types.ts
+++ b/packages/uikit/src/components/Link/types.ts
@@ -7,4 +7,5 @@ export interface LinkProps extends TextProps, AnchorHTMLAttributes<HTMLAnchorEle
   isBscScan?: boolean;
   hoverBackgroundColor?: string;
   padding?: string;
+  textDecoration?: string;
 }


### PR DESCRIPTION
Removed underlining for learn more buttons

Removed underlining for learn more buttons
Added hover effect to Learn more buttons
Before:
![image](https://github.com/vertotrade/verto.ui/assets/150782162/a2d5ef79-e067-4cf9-ad29-1cca538db9dd)
![image](https://github.com/vertotrade/verto.ui/assets/150782162/6e1ec26f-d67b-45f6-93e4-e7e68da4ba39)
![image](https://github.com/vertotrade/verto.ui/assets/150782162/22450af2-519c-4c57-81c0-d205ae494086)
![image](https://github.com/vertotrade/verto.ui/assets/150782162/16ab57cd-cd63-4199-8678-162e6d8723f1)
After:
![image](https://github.com/vertotrade/verto.ui/assets/150782162/06f9f5a9-c238-4c0b-bffe-979bbf3ab96a)
![image](https://github.com/vertotrade/verto.ui/assets/150782162/4322da29-1df8-49c0-9b6c-5ace51e0af5d)
![image](https://github.com/vertotrade/verto.ui/assets/150782162/a7b717c3-8de9-45ed-9e03-575456f76352)
![image](https://github.com/vertotrade/verto.ui/assets/150782162/83d6b5b3-6456-4fef-af8e-bcd1b99fc49f)

