### PR TITLE
remove background color from social links in footer section

### DIFF
--- a/packages/uikit/src/components/Footer/Components/SocialLinks.tsx
+++ b/packages/uikit/src/components/Footer/Components/SocialLinks.tsx
@@ -31,7 +31,14 @@ const SocialLinks: React.FC<React.PropsWithChildren<FlexProps>> = ({ ...props })
       const mr = index < socials.length - 1 ? "24px" : 0;
 
       return (
-        <SocialLink external key={social.label} href={social.href} aria-label={social.label} mr={mr}>
+        <SocialLink
+          external
+          key={social.label}
+          href={social.href}
+          aria-label={social.label}
+          mr={mr}
+          hoverBackgroundColor="inherit"
+        >
           <Icon {...iconProps} />
         </SocialLink>
       );


### PR DESCRIPTION
Remove background color from social links
Before:
![image](https://github.com/vertotrade/verto.ui/assets/150782162/5b86f5b5-6d31-458a-99e7-ceba1d3bc79c)
After

https://github.com/vertotrade/verto.ui/assets/150782162/3ef6e3a7-7ac0-4151-929d-3ce94911e120

