### PR TITLE
Dev 719 remove icon from learn more

### DIFF
--- a/apps/web/src/views/Home/components/SalesSection/data.tsx
+++ b/apps/web/src/views/Home/components/SalesSection/data.tsx
@@ -17,6 +17,7 @@ export const swapSectionData = (t: TranslateFunction, isDark: boolean): SalesSec
     to: 'https://docs.vertotrade.com/',
     text: t('Learn more'),
     external: true,
+    isIcon: false,
   },
   images: {
     path: '/images/home/trade/',
@@ -44,6 +45,7 @@ export const earnSectionData = (t: TranslateFunction, isDark: boolean): SalesSec
     to: 'https://docs.vertotrade.com/products/yield-farming',
     text: t('Learn more'),
     external: true,
+    isIcon: false,
   },
   images: {
     path: '/images/home/earn/',
@@ -73,6 +75,7 @@ export const vertoSectionData = (t: TranslateFunction, isDark: boolean, theme: a
     to: 'https://docs.vertotrade.com/tokenomics/verto/#verto',
     text: t('Learn more'),
     external: true,
+    isIcon: false,
   },
 
   images: {

--- a/apps/web/src/views/Home/components/SalesSection/index.tsx
+++ b/apps/web/src/views/Home/components/SalesSection/index.tsx
@@ -4,10 +4,17 @@ import { useTheme } from '@verto/hooks'
 import { CompositeImageProps } from '../CompositeImage'
 import ColoredWordHeading from '../ColoredWordHeading'
 
-interface SalesSectionButton {
+interface SalesSectionButtonPrimary {
   to: string
   text: string
   external: boolean
+}
+
+interface SalesSectionButtonSecondary {
+  to: string
+  text: string
+  external: boolean
+  isIcon: boolean
 }
 
 const ContentWrapper = styled(Flex)<{ addStyles?: boolean }>`
@@ -61,8 +68,8 @@ export interface SalesSectionProps {
   headingText: string
   bodyText: string
   reverse: boolean
-  primaryButton: SalesSectionButton
-  secondaryButton: SalesSectionButton
+  primaryButton: SalesSectionButtonPrimary
+  secondaryButton: SalesSectionButtonSecondary
   images: CompositeImageProps
   colorOverride?: boolean
   ClipComponent?: React.ComponentType
@@ -124,6 +131,7 @@ const SalesSection: React.FC<React.PropsWithChildren<SalesSectionProps>> = props
               </Button>
               {secondaryButton.external ? (
                 <LinkExternal
+                  isIcon={secondaryButton.isIcon}
                   color={theme.colors.text}
                   textDecoration="none"
                   href={secondaryButton.to}

--- a/apps/web/src/views/Home/index.tsx
+++ b/apps/web/src/views/Home/index.tsx
@@ -161,7 +161,7 @@ const Home: React.FC<React.PropsWithChildren> = () => {
                 {t('Connect your crypto wallet to start using the app in seconds. No registration needed.')}
               </StyledText>
               <Flex
-                justifyContent="center"
+                justifyContent="flex-start"
                 align-items="center"
                 flexDirection={['column', null, 'row']}
                 mr={['auto', null, 'unset']}>
@@ -178,6 +178,7 @@ const Home: React.FC<React.PropsWithChildren> = () => {
                   padding="0 20px"
                   textDecoration="none"
                   hoverBackgroundColor={theme.isDark ? 'white' : theme.colors.secondaryButtonHoverBg}
+                  isIcon={false}
                   external
                   href="https://docs.vertotrade.com/">
                   {t('Learn how to start')}

--- a/packages/uikit/src/components/Link/LinkExternal.tsx
+++ b/packages/uikit/src/components/Link/LinkExternal.tsx
@@ -4,13 +4,18 @@ import { LinkProps } from "./types";
 import OpenNewIcon from "../Svg/Icons/OpenNew";
 import BscScanIcon from "../Svg/Icons/BscScan";
 
-const LinkExternal: React.FC<React.PropsWithChildren<LinkProps>> = ({ children, isBscScan = false, ...props }) => {
+const LinkExternal: React.FC<React.PropsWithChildren<LinkProps>> = ({
+  children,
+  isBscScan = false,
+  isIcon = true,
+  ...props
+}) => {
   const color = useMemo(() => (props.color ? props.color : "link"), [props.color]);
 
   return (
     <Link external color={color} {...props}>
       {children}
-      {isBscScan ? <BscScanIcon color={color} ml="4px" /> : <OpenNewIcon color={color} ml="4px" />}
+      {isIcon ? isBscScan ? <BscScanIcon color={color} ml="4px" /> : <OpenNewIcon color={color} ml="4px" /> : ""}
     </Link>
   );
 };

--- a/packages/uikit/src/components/Link/types.ts
+++ b/packages/uikit/src/components/Link/types.ts
@@ -5,6 +5,7 @@ export interface LinkProps extends TextProps, AnchorHTMLAttributes<HTMLAnchorEle
   external?: boolean;
   internal?: boolean;
   isBscScan?: boolean;
+  isIcon?: boolean;
   hoverBackgroundColor?: string;
   padding?: string;
   textDecoration?: string;


### PR DESCRIPTION
Removed icons from Learn More buttons.
A linting issue appeared in setupTests.js because of it file type I updated the file changing the file type to setupTests.ts.

PS: In order to stay consistent with UI I also removed the icon for Learn how to start button

Before:
![image](https://github.com/vertotrade/verto.ui/assets/150782162/e8f7af93-0821-4791-ad0d-0a0a367d498d)
![image](https://github.com/vertotrade/verto.ui/assets/150782162/896f5139-b70d-4773-8779-0cd54fb8ea37)
![image](https://github.com/vertotrade/verto.ui/assets/150782162/8ee55902-0393-4c2c-b318-ab7c596444a4)
![image](https://github.com/vertotrade/verto.ui/assets/150782162/bd0cb530-6aaa-4046-a8d8-b6ba974c861d)
After:
![image](https://github.com/vertotrade/verto.ui/assets/150782162/3d96ce6f-d0b4-4507-96dc-1b372d9eee97)
![image](https://github.com/vertotrade/verto.ui/assets/150782162/5814933b-8e92-4c70-81db-073fb3f6f868)
![image](https://github.com/vertotrade/verto.ui/assets/150782162/b505ea88-a439-4f29-afa9-d8e9cce31a74)
![image](https://github.com/vertotrade/verto.ui/assets/150782162/43059287-a608-4133-9a25-cc957a2115b2)
