### PR TITLE
DEV-744 Fix text-align on small screens

### DIFF
--- a/apps/web/src/views/Home/index.tsx
+++ b/apps/web/src/views/Home/index.tsx
@@ -45,10 +45,6 @@ const VertoRowWrapper = styled(Flex)`
 
 const StyledText = styled(Text)`
   text-align: left;
-
-  @media screen and (max-width: 900px) {
-    text-align: center;
-  }
 `
 
 const FooterWrapper = styled(Flex)`


### PR DESCRIPTION
**Task**
[DEV-744](https://rebustoken.atlassian.net/browse/DEV-744?atlOrigin=eyJpIjoiNTFhNmVmZDM2YjhhNGFkMWEzNTk1ZDlmZDVlZjExZGIiLCJwIjoiaiJ9)

**Description**
On small screens, the text on different sections in the home page should be left-aligned.

Before:
<img width="455" alt="Screenshot 2023-11-28 at 1 33 40 PM" src="https://github.com/vertotrade/verto.ui/assets/14368843/2b629110-3945-4574-bb8e-bf99cc1c42d2">

After:
<img width="455" alt="Screenshot 2023-11-28 at 1 33 50 PM" src="https://github.com/vertotrade/verto.ui/assets/14368843/c8fe82d6-1acb-488c-863c-653176d6252a">
