### PR TITLE
DEV-740 Remove background color in header and tabs sections.

### DIFF
--- a/apps/web/src/components/Menu/UserMenu/WalletModal.tsx
+++ b/apps/web/src/components/Menu/UserMenu/WalletModal.tsx
@@ -32,12 +32,10 @@ interface WalletModalProps extends InjectedModalProps {
 export const LOW_NATIVE_BALANCE = parseUnits('0.002', 'ether')
 
 const ModalHeader = styled(UIKitModalHeader)`
-  background: ${({ theme }) => theme.colors.backgroundAlt};
   border-bottom: none;
 `
 
 const Tabs = styled.div`
-  background-color: ${({ theme }) => theme.colors.dropdown};
   padding: 16px 24px;
 `
 


### PR DESCRIPTION
**Task**
[DEV-740](https://rebustoken.atlassian.net/browse/DEV-740?atlOrigin=eyJpIjoiYjhhYjQ3YmMwMDkzNGM4MDhkMWMwNmQ0Y2ZlMGE2OGUiLCJwIjoiaiJ9)

**Description**
Removes the background color for both header and tabs section in the wallet modal

Before:
<img width="720" alt="Screenshot 2023-11-30 at 1 59 20 PM" src="https://github.com/vertotrade/verto.ui/assets/14368843/7373af1f-3481-44f7-97d6-94c8260d94a7">
<img width="720" alt="Screenshot 2023-11-30 at 1 59 09 PM" src="https://github.com/vertotrade/verto.ui/assets/14368843/9f205e9d-af79-49cd-a8ee-741dbf9c485a">

After:
<img width="720" alt="Screenshot 2023-11-30 at 1 59 48 PM" src="https://github.com/vertotrade/verto.ui/assets/14368843/62f85964-d127-4a13-b7de-56d90232d21f">
<img width="720" alt="Screenshot 2023-11-30 at 1 59 38 PM" src="https://github.com/vertotrade/verto.ui/assets/14368843/dd9ed459-642e-450e-bbd3-317a9156bbf1">
