### PR TITLE
DEV-776: Update nft Details dropdown component

### DIFF
--- a/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/OneOfAKindNftPage/OwnerCard.tsx
+++ b/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/OneOfAKindNftPage/OwnerCard.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
-import { Flex, Card, Grid, SellIcon, Text, useModal, Box, Skeleton, Button } from '@verto/uikit'
+import { Flex, Grid, Text, useModal, Box, Skeleton, Button } from '@verto/uikit'
 import { useTranslation } from '@verto/localization'
-import useTheme from 'hooks/useTheme'
 import { CurrencyLogo } from 'components/Logo'
 import { NftToken } from 'state/nftMarket/types'
 import { formatNumber } from '@verto/utils/formatBalance'
@@ -12,14 +11,7 @@ import BuyModal from '../../../components/BuySellModals/BuyModal'
 import SellModal from '../../../components/BuySellModals/SellModal'
 import ProfileCell from '../../../components/ProfileCell'
 import { ButtonContainer, TableHeading } from '../shared/styles'
-
-const StyledCard = styled(Card)`
-  width: 100%;
-  & > div:first-child {
-    display: flex;
-    flex-direction: column;
-  }
-`
+import ExpandableCard from '../shared/ExpandableCard'
 
 const OwnerRow = styled(Grid)`
   grid-template-columns: 2fr 2fr 1fr;
@@ -27,6 +19,11 @@ const OwnerRow = styled(Grid)`
   margin-top: 16px;
   margin-bottom: 8px;
   align-items: center;
+`
+
+const StyledText = styled(Text)`
+  color: ${({ theme }) => `${theme.colors.tableHeader}`};
+  font-size: 14px;
 `
 
 interface OwnerCardProps {
@@ -44,7 +41,6 @@ const OwnerCard: React.FC<React.PropsWithChildren<OwnerCardProps>> = ({
   onSuccess,
 }) => {
   const { t } = useTranslation()
-  const { theme } = useTheme()
 
   const { owner, isLoadingOwner } = useNftOwner(nft, isOwnNft)
 
@@ -56,29 +52,15 @@ const OwnerCard: React.FC<React.PropsWithChildren<OwnerCardProps>> = ({
     <SellModal variant={nft.marketData?.isTradable ? 'edit' : 'sell'} nftToSell={nft} onSuccessSale={onSuccess} />,
   )
 
-  return (
-    <StyledCard>
-      <Grid
-        flex="0 1 auto"
-        gridTemplateColumns="34px 1fr"
-        alignItems="center"
-        height="72px"
-        px="24px"
-        borderBottom={`1px solid ${theme.colors.cardBorder}`}>
-        <SellIcon width="24px" height="24px" />
-        <Text bold>{t('Owner')}</Text>
-      </Grid>
+  const content = (
+    <Box background="transparent" pt="10px">
       {owner && (
         <>
           <TableHeading flex="0 1 auto" gridTemplateColumns="2fr 2fr 1fr" py="12px">
             <Flex alignItems="center">
-              <Text textTransform="uppercase" color="textSubtle" bold fontSize="12px" px="24px">
-                {t('Price')}
-              </Text>
+              <StyledText pl="24px">{t('Price')}</StyledText>
             </Flex>
-            <Text textTransform="uppercase" color="textSubtle" bold fontSize="12px">
-              {t('Owner')}
-            </Text>
+            <StyledText>{t('Owner')}</StyledText>
           </TableHeading>
           <OwnerRow>
             <Box pl="24px">
@@ -95,7 +77,7 @@ const OwnerCard: React.FC<React.PropsWithChildren<OwnerCardProps>> = ({
                       {`(~${formatNumber(priceInUsd, 2, 2)} USD)`}
                     </Text>
                   ) : (
-                    <Skeleton width="86px" height="12px" mt="4px" />
+                    ''
                   )}
                 </>
               ) : (
@@ -122,10 +104,11 @@ const OwnerCard: React.FC<React.PropsWithChildren<OwnerCardProps>> = ({
               ) : (
                 <Button
                   disabled={!nft.marketData?.isTradable}
-                  scale="sm"
+                  scale="md"
                   variant="secondary"
                   maxWidth="128px"
-                  onClick={onPresentBuyModal}>
+                  onClick={onPresentBuyModal}
+                  style={{ fontSize: '16px' }}>
                   {t('Buy')}
                 </Button>
               )}
@@ -139,8 +122,9 @@ const OwnerCard: React.FC<React.PropsWithChildren<OwnerCardProps>> = ({
           <Text>{t('Owner information is not available for this item')}</Text>
         </Flex>
       )}
-    </StyledCard>
+    </Box>
   )
+  return <ExpandableCard title={t('Owner')} content={content} />
 }
 
 export default OwnerCard

--- a/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/OneOfAKindNftPage/index.tsx
+++ b/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/OneOfAKindNftPage/index.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react'
-import styled from 'styled-components'
 import { Flex } from '@verto/uikit'
 import sum from 'lodash/sum'
 import noop from 'lodash/noop'
@@ -8,7 +7,6 @@ import { useGetCollection } from 'state/nftMarket/hooks'
 import PageLoader from 'components/Loader/PageLoader'
 import fromPairs from 'lodash/fromPairs'
 import MainNFTCard from './MainNFTCard'
-import { TwoColumnsContainer } from '../shared/styles'
 import PropertiesCard from '../shared/PropertiesCard'
 import DetailsCard from '../shared/DetailsCard'
 import useGetCollectionDistribution from '../../../hooks/useGetCollectionDistribution'
@@ -22,10 +20,6 @@ interface IndividualNFTPageProps {
   collectionAddress: string
   tokenId: string
 }
-
-const OwnerActivityContainer = styled(Flex)`
-  gap: 22px;
-`
 
 const IndividualNFTPage: React.FC<React.PropsWithChildren<IndividualNFTPageProps>> = ({
   collectionAddress,
@@ -68,23 +62,19 @@ const IndividualNFTPage: React.FC<React.PropsWithChildren<IndividualNFTPageProps
   return (
     <Page>
       <MainNFTCard nft={nft} isOwnNft={isOwnNft} nftIsProfilePic={isProfilePic} onSuccess={refetch} />
-      <TwoColumnsContainer flexDirection={['column', 'column', 'column', 'column', 'row']}>
-        <Flex flexDirection="column" width="100%">
-          <ManageNFTsCard collection={collection} tokenId={tokenId} onSuccess={isOwnNft ? refetch : noop} />
-          <PropertiesCard properties={properties} rarity={attributesRarity} />
-          <DetailsCard contractAddress={collectionAddress} ipfsJson={nft?.marketData?.metadataUrl} />
-        </Flex>
-        <OwnerActivityContainer flexDirection="column" width="100%">
-          <OwnerCard
-            contractCollection={contractCollection}
-            nft={nft}
-            isOwnNft={isOwnNft}
-            nftIsProfilePic={isProfilePic}
-            onSuccess={refetch}
-          />
-          {/* <ActivityCard nft={nft} /> */}
-        </OwnerActivityContainer>
-      </TwoColumnsContainer>
+      <Flex flexDirection="column" maxWidth="656px" width="100%" style={{ gap: '16px' }}>
+        <ManageNFTsCard collection={collection} tokenId={tokenId} onSuccess={isOwnNft ? refetch : noop} />
+        <PropertiesCard properties={properties} rarity={attributesRarity} />
+        <DetailsCard contractAddress={collectionAddress} ipfsJson={nft?.marketData?.metadataUrl} />
+        <OwnerCard
+          contractCollection={contractCollection}
+          nft={nft}
+          isOwnNft={isOwnNft}
+          nftIsProfilePic={isProfilePic}
+          onSuccess={refetch}
+        />
+        {/* <ActivityCard nft={nft} /> */}
+      </Flex>
       <MoreFromThisCollection collectionAddress={collectionAddress} currentTokenName={nft.name} />
     </Page>
   )

--- a/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/shared/DetailsCard.tsx
+++ b/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/shared/DetailsCard.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { Box, Flex, Text, SearchIcon, Link } from '@verto/uikit'
+import { Flex, Text, Link } from '@verto/uikit'
 import { getBlockExploreLink } from 'utils'
 import { formatNumber } from '@verto/utils/formatBalance'
 import uriToHttp from '@verto/utils/uriToHttp'
@@ -21,6 +21,11 @@ const LongTextContainer = styled(Text)`
   text-overflow: ellipsis;
 `
 
+const StyledText = styled(Text)`
+  color: ${({ theme }) => `${theme.colors.placeholder}`};
+  font-size: 14px;
+`
+
 const DetailsCard: React.FC<React.PropsWithChildren<DetailsCardProps>> = ({
   contractAddress,
   ipfsJson,
@@ -31,44 +36,36 @@ const DetailsCard: React.FC<React.PropsWithChildren<DetailsCardProps>> = ({
   const { chainId } = useActiveChainId()
   const ipfsLink = ipfsJson ? uriToHttp(ipfsJson)[0] : null
   const content = (
-    <Box p="24px">
-      <Flex justifyContent="space-between" alignItems="center" mb="16px">
-        <Text fontSize="12px" color="textSubtle" bold textTransform="uppercase">
-          {t('Contract address')}
-        </Text>
+    <Flex justifyContent="space-between" pt="24px">
+      <Flex justifyContent="space-between" alignItems="start" flexDirection="column">
+        <StyledText>{t('Contract address')}</StyledText>
         <Link external href={getBlockExploreLink(contractAddress, 'address', chainId)}>
           <LongTextContainer bold>{contractAddress}</LongTextContainer>
         </Link>
       </Flex>
       {ipfsLink && (
-        <Flex justifyContent="space-between" alignItems="center" mb="16px">
-          <Text fontSize="12px" color="textSubtle" bold textTransform="uppercase">
-            IPFS JSON
-          </Text>
+        <Flex justifyContent="space-between" alignItems="center">
+          <StyledText>IPFS JSON</StyledText>
           <Link external href={ipfsLink}>
             <LongTextContainer bold>{ipfsLink}</LongTextContainer>
           </Link>
         </Flex>
       )}
       {count && (
-        <Flex justifyContent="space-between" alignItems="center" mb="16px" mr="4px">
-          <Text fontSize="12px" color="textSubtle" bold textTransform="uppercase">
-            {t('Supply Count')}
-          </Text>
+        <Flex justifyContent="space-between" alignItems="center" mr="4px">
+          <StyledText>{t('Supply Count')}</StyledText>
           <LongTextContainer bold>{formatNumber(count, 0, 0)}</LongTextContainer>
         </Flex>
       )}
       {rarity && (
         <Flex justifyContent="space-between" alignItems="center" mr="4px">
-          <Text fontSize="12px" color="textSubtle" bold textTransform="uppercase">
-            {t('Rarity')}
-          </Text>
+          <StyledText>{t('Rarity')}</StyledText>
           <LongTextContainer bold>{`${formatNumber(rarity, 0, 2)}%`}</LongTextContainer>
         </Flex>
       )}
-    </Box>
+    </Flex>
   )
-  return <ExpandableCard title={t('Details')} icon={<SearchIcon width="24px" height="24px" />} content={content} />
+  return <ExpandableCard title={t('Details')} content={content} />
 }
 
 export default DetailsCard

--- a/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/shared/ExpandableCard.tsx
+++ b/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/shared/ExpandableCard.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import styled, { keyframes, css } from 'styled-components'
-import { Grid, Text, Card, Box, ChevronUpIcon, ChevronDownIcon, IconButton } from '@verto/uikit'
-import useTheme from 'hooks/useTheme'
+import { Flex, Text, Card, Box, ChevronUpIcon, ChevronDownIcon, IconButton } from '@verto/uikit'
 
 const expandAnimation = keyframes`
   from {
@@ -34,27 +33,24 @@ const ExpandableCardBody = styled(Box)<{ expanded: boolean }>`
 
 const FullWidthCard = styled(Card)`
   width: 100%;
+  background: ${({ theme }) => `${theme.colors.vertoBg1}`};
+  border: 1px solid ${({ theme }) => `${theme.colors.hr}`};
 `
 
 interface ExpandableCardProps {
-  icon: React.ReactNode
   title: string
   content: React.ReactNode
 }
 
-const ExpandableCard: React.FC<React.PropsWithChildren<ExpandableCardProps>> = ({ icon, title, content }) => {
+const ExpandableCard: React.FC<React.PropsWithChildren<ExpandableCardProps>> = ({ title, content }) => {
   const [expanded, setExpanded] = useState(true)
-  const { theme } = useTheme()
+
   return (
-    <FullWidthCard>
-      <Grid
-        gridTemplateColumns="1fr 8fr 1fr"
-        alignItems="center"
-        height="72px"
-        px="24px"
-        borderBottom={`1px solid ${theme.colors.cardBorder}`}>
-        {icon}
-        <Text bold>{title}</Text>
+    <FullWidthCard background="transparent">
+      <Flex justifyContent="space-between" alignItems="center">
+        <Text fontWeight="600" fontFamily="Poppins,sans-serif">
+          {title}
+        </Text>
         <IconButton
           onClick={() => {
             setExpanded(prev => !prev)
@@ -67,7 +63,7 @@ const ExpandableCard: React.FC<React.PropsWithChildren<ExpandableCardProps>> = (
             <ChevronDownIcon width="24px" height="24px" color="textSubtle" />
           )}
         </IconButton>
-      </Grid>
+      </Flex>
       <ExpandableCardBody expanded={expanded}>{content}</ExpandableCardBody>
     </FullWidthCard>
   )

--- a/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/shared/ManageNFTsCard.tsx
+++ b/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/shared/ManageNFTsCard.tsx
@@ -1,16 +1,5 @@
 import styled from 'styled-components'
-import {
-  Box,
-  Flex,
-  Grid,
-  Text,
-  CogIcon,
-  SellIcon,
-  WalletFilledIcon,
-  CameraIcon,
-  Skeleton,
-  useModal,
-} from '@verto/uikit'
+import { Box, Flex, Grid, Text, SellIcon, WalletFilledIcon, CameraIcon, Skeleton, useModal } from '@verto/uikit'
 import { useAccount } from 'wagmi'
 import { useProfile } from 'state/profile/hooks'
 import { NftLocation, NftToken, Collection } from 'state/nftMarket/types'
@@ -192,7 +181,7 @@ const ManageNFTsCard: React.FC<React.PropsWithChildren<ManageNftsCardProps>> = (
   const totalNftsText = account && !userHasNoNfts ? ` (${totalNfts})` : ''
 
   const content = (
-    <Box pt="16px">
+    <Box pt="24px">
       {!account && (
         <Flex mb="16px" justifyContent="center">
           <ConnectWalletButton />
@@ -254,7 +243,6 @@ const ManageNFTsCard: React.FC<React.PropsWithChildren<ManageNftsCardProps>> = (
   return (
     <ExpandableCard
       title={`${tokenId ? t('Manage Yours') : t('Manage Yours in Collection')}${totalNftsText}`}
-      icon={<CogIcon width="24px" height="24px" />}
       content={content}
     />
   )

--- a/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/shared/PropertiesCard.tsx
+++ b/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/shared/PropertiesCard.tsx
@@ -1,4 +1,5 @@
-import { Box, Flex, Text, NftIcon } from '@verto/uikit'
+import styled from 'styled-components'
+import { Flex, Text } from '@verto/uikit'
 import { useTranslation } from '@verto/localization'
 import { NftAttribute } from 'state/nftMarket/types'
 import ExpandableCard from './ExpandableCard'
@@ -13,34 +14,44 @@ const KNOWN_TRAITS_TEXT = {
   bunnyId: 'Bunny ID',
 }
 
+const StyledFlex = styled(Flex)`
+  gap: 10px;
+  flex-wrap: wrap;
+`
+
+const StyledProperty = styled(Flex)`
+  min-width: 145px;
+  alighn-items: center;
+  flex-direction: column;
+  background: ${({ theme }) => `${theme.colors.secondaryButtonBg}`};
+  border-radius: 8px;
+  padding: 8px 16px;
+
+  > div {
+    color: ${({ theme }) => `${theme.colors.placeholder}`};
+  }
+`
+
 const SingleProperty: React.FC<React.PropsWithChildren<{ title: string; value: string | number; rarity: number }>> = ({
   title,
   value,
-  rarity,
 }) => {
   return (
-    <Flex justifyContent="space-between" alignItems="center">
-      <Text fontSize="12px" color="textSubtle" bold textTransform="uppercase">
-        {KNOWN_TRAITS_TEXT[title] ?? title}
-      </Text>
+    <StyledProperty>
+      <Text fontSize="14px">{KNOWN_TRAITS_TEXT[title] ?? title}</Text>
       <Flex alignItems="center">
-        <Text bold textTransform="uppercase" mr="4px">
+        <Text bold fontWeight="600">
           {value}
         </Text>
-        {rarity && (
-          <Text small color="textSubtle">
-            ({rarity.toFixed(2)}%)
-          </Text>
-        )}
       </Flex>
-    </Flex>
+    </StyledProperty>
   )
 }
 
 const PropertiesCard: React.FC<React.PropsWithChildren<PropertiesCardProps>> = ({ properties, rarity }) => {
   const { t } = useTranslation()
   const content = (
-    <Box p="24px">
+    <StyledFlex pt="24px">
       {properties.map(property => (
         <SingleProperty
           key={property.traitType}
@@ -49,9 +60,9 @@ const PropertiesCard: React.FC<React.PropsWithChildren<PropertiesCardProps>> = (
           rarity={rarity[property.traitType]}
         />
       ))}
-    </Box>
+    </StyledFlex>
   )
-  return <ExpandableCard title={t('Properties')} icon={<NftIcon width="24px" height="24px" />} content={content} />
+  return <ExpandableCard title={t('Properties')} content={content} />
 }
 
 export default PropertiesCard

--- a/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/shared/styles.tsx
+++ b/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/shared/styles.tsx
@@ -1,18 +1,6 @@
 import styled from 'styled-components'
 import { Box, Flex, Grid, Image, NextLinkFromReactRouter } from '@verto/uikit'
 
-export const TwoColumnsContainer = styled(Flex)`
-  gap: 22px;
-  align-items: flex-start;
-  & > div:first-child {
-    flex: 1;
-    gap: 20px;
-  }
-  & > div:last-child {
-    flex: 2;
-  }
-`
-
 export const RoundedImage = styled(Image)`
   height: max-content;
   border-radius: ${({ theme }) => theme.radii.default};

--- a/apps/web/src/views/Nft/market/components/CollectibleCard/CollectionCard.tsx
+++ b/apps/web/src/views/Nft/market/components/CollectibleCard/CollectionCard.tsx
@@ -56,7 +56,6 @@ const StyledCardDetailsContainer = styled.div`
 
 const CollectionCard: React.FC<React.PropsWithChildren<CollectionCardProps>> = ({
   bgSrc,
-  avatarSrc,
   collectionName,
   collectionVolume,
   collectionSupply,


### PR DESCRIPTION
Updated nft Details dropdown components UI due to [Figma](https://www.figma.com/file/kgG2H5rFVnvZjiPJ95Hq8G/Verto-trade?node-id=5110%3A5706&mode=dev):
<img width="1167" alt="Screenshot 2023-12-29 at 2 43 28 PM" src="https://github.com/vertotrade/verto.ui/assets/46223860/92e65250-0893-4ffd-9ac0-c2f1a62180f2">
<img width="1167" alt="Screenshot 2023-12-29 at 2 44 34 PM" src="https://github.com/vertotrade/verto.ui/assets/46223860/4720786c-2eb4-443e-a253-0c1cdd4dd441">
