### PR TITLE
DEV-779, DEV- 781: fix loading spinner on checkout, display gas price

### DIFF
--- a/apps/web/src/views/Nft/market/components/BuySellModals/BuyModal/index.tsx
+++ b/apps/web/src/views/Nft/market/components/BuySellModals/BuyModal/index.tsx
@@ -9,6 +9,7 @@ import { useERC20, useNftMarketContract } from 'hooks/useContract'
 import useTheme from 'hooks/useTheme'
 import useTokenBalance from 'hooks/useTokenBalance'
 import useSWR from 'swr'
+import { useGasPrice } from 'state/user/hooks'
 import { useState } from 'react'
 import { NftToken } from 'state/nftMarket/types'
 import { useTokenAndPriceByAddress } from 'utils/prices'
@@ -69,6 +70,8 @@ const BuyModal: React.FC<React.PropsWithChildren<BuyModalProps>> = ({ nftToBuy, 
   const walletBalance = getBalanceNumber(balance, token?.decimals)
 
   const notEnoughForPurchase = balance.lt(ethersToBigNumber(nftPriceWei))
+
+  const gasPrice = useGasPrice()
 
   const {
     isApproving: vertoIsApproving,
@@ -158,6 +161,7 @@ const BuyModal: React.FC<React.PropsWithChildren<BuyModalProps>> = ({ nftToBuy, 
         <ApproveAndConfirmStage
           token={token}
           variant="buy"
+          gasPrice={gasPrice}
           handleApprove={handleApprove}
           isApproved={isApproved}
           isApproving={isApproving}

--- a/apps/web/src/views/Nft/market/components/BuySellModals/shared/ApproveAndConfirmStage.tsx
+++ b/apps/web/src/views/Nft/market/components/BuySellModals/shared/ApproveAndConfirmStage.tsx
@@ -1,3 +1,4 @@
+import styled from 'styled-components'
 import { Flex, Text, Button, Spinner } from '@verto/uikit'
 import { useTranslation } from '@verto/localization'
 import { ERC20Token } from '@verto/sdk'
@@ -15,6 +16,14 @@ interface ApproveAndConfirmStageProps {
   vertoIsApproving: boolean
   vertoHandleApprove: () => void
 }
+
+const SpinnerWrapper = styled(Flex)`
+  padding-left: 10px;
+
+  & > div {
+    margin: 0;
+  }
+`
 
 // Buy Flow:
 // Shown if user wants to pay and contract isn't approved yet
@@ -37,7 +46,7 @@ const ApproveAndConfirmStage: React.FC<React.PropsWithChildren<ApproveAndConfirm
 
   return (
     <Flex p="16px" flexDirection="column">
-      <Flex mb="8px" alignItems="center">
+      <Flex mb="8px" alignItems="center" justifyContent="space-between">
         <Flex flexDirection="column">
           <Flex alignItems="center">
             <StepIndicator success={isApproved}>
@@ -57,9 +66,9 @@ const ApproveAndConfirmStage: React.FC<React.PropsWithChildren<ApproveAndConfirm
             </Text>
           )}
         </Flex>
-        <Flex flex="0 0 64px" width="64px">
+        <SpinnerWrapper flex="0 0 64px" width="64px">
           {isApproving && <Spinner size={64} />}
-        </Flex>
+        </SpinnerWrapper>
       </Flex>
       {!isApproved && (
         <Button variant="secondary" disabled={isApproving} onClick={handleApprove}>
@@ -69,7 +78,7 @@ const ApproveAndConfirmStage: React.FC<React.PropsWithChildren<ApproveAndConfirm
 
       {variant === 'buy' && (
         <>
-          <Flex alignItems="center" mt="8px">
+          <Flex alignItems="center" mt="8px" justifyContent="space-between">
             <Flex flexDirection="column">
               <Flex alignItems="center" mt="16px">
                 <StepIndicator success={vertoIsApproved} disabled={!isApproved && !vertoIsApproved}>
@@ -90,9 +99,9 @@ const ApproveAndConfirmStage: React.FC<React.PropsWithChildren<ApproveAndConfirm
                 </Text>
               )}
             </Flex>
-            <Flex flex="0 0 64px" width="64px">
+            <SpinnerWrapper flex="0 0 64px" width="64px">
               {vertoIsApproving && <Spinner size={64} />}
-            </Flex>
+            </SpinnerWrapper>
           </Flex>
           {!vertoIsApproved && (
             <Button
@@ -106,7 +115,7 @@ const ApproveAndConfirmStage: React.FC<React.PropsWithChildren<ApproveAndConfirm
         </>
       )}
 
-      <Flex alignItems="center" mt="8px">
+      <Flex alignItems="center" mt="8px" justifyContent="space-between">
         <Flex flexDirection="column">
           <Flex alignItems="center" mt="16px">
             <StepIndicator success={!!0} disabled={!isApproved || !secondStepApproved}>
@@ -125,9 +134,9 @@ const ApproveAndConfirmStage: React.FC<React.PropsWithChildren<ApproveAndConfirm
             {t('Please confirm the transaction in your wallet')}
           </Text>
         </Flex>
-        <Flex flex="0 0 64px" width="64px">
+        <SpinnerWrapper flex="0 0 64px" width="64px">
           {isConfirming && <Spinner size={64} />}
-        </Flex>
+        </SpinnerWrapper>
       </Flex>
       <Button
         mt="16px"

--- a/apps/web/src/views/Nft/market/components/BuySellModals/shared/ApproveAndConfirmStage.tsx
+++ b/apps/web/src/views/Nft/market/components/BuySellModals/shared/ApproveAndConfirmStage.tsx
@@ -1,4 +1,3 @@
-import styled from 'styled-components'
 import { Flex, Text, Button, Spinner } from '@verto/uikit'
 import { useTranslation } from '@verto/localization'
 import { ERC20Token } from '@verto/sdk'
@@ -17,14 +16,6 @@ interface ApproveAndConfirmStageProps {
   vertoIsApproving: boolean
   vertoHandleApprove: () => void
 }
-
-const SpinnerWrapper = styled(Flex)`
-  padding-left: 10px;
-
-  & > div {
-    margin: 0;
-  }
-`
 
 // Buy Flow:
 // Shown if user wants to pay and contract isn't approved yet
@@ -68,9 +59,7 @@ const ApproveAndConfirmStage: React.FC<React.PropsWithChildren<ApproveAndConfirm
             </Text>
           )}
         </Flex>
-        <SpinnerWrapper flex="0 0 64px" width="64px">
-          {isApproving && <Spinner size={64} />}
-        </SpinnerWrapper>
+        {isApproving && <Spinner size={64} />}
       </Flex>
       {!isApproved && (
         <Button variant="secondary" disabled={isApproving} onClick={handleApprove}>
@@ -101,9 +90,7 @@ const ApproveAndConfirmStage: React.FC<React.PropsWithChildren<ApproveAndConfirm
                 </Text>
               )}
             </Flex>
-            <SpinnerWrapper flex="0 0 64px" width="64px">
-              {vertoIsApproving && <Spinner size={64} />}
-            </SpinnerWrapper>
+            {vertoIsApproving && <Spinner size={64} />}
           </Flex>
           {!vertoIsApproved && (
             <Button
@@ -136,9 +123,7 @@ const ApproveAndConfirmStage: React.FC<React.PropsWithChildren<ApproveAndConfirm
             {t('Please confirm the transaction in your wallet')}
           </Text>
         </Flex>
-        <SpinnerWrapper flex="0 0 64px" width="64px">
-          {isConfirming && <Spinner size={64} />}
-        </SpinnerWrapper>
+        {isConfirming && <Spinner size={64} />}
       </Flex>
       <Button
         mt="16px"

--- a/apps/web/src/views/Nft/market/components/BuySellModals/shared/ApproveAndConfirmStage.tsx
+++ b/apps/web/src/views/Nft/market/components/BuySellModals/shared/ApproveAndConfirmStage.tsx
@@ -7,6 +7,7 @@ import { StepIndicator } from './styles'
 interface ApproveAndConfirmStageProps {
   token: ERC20Token
   variant: 'buy' | 'sell'
+  gasPrice?: string
   isApproved: boolean
   isApproving: boolean
   isConfirming: boolean
@@ -32,6 +33,7 @@ const SpinnerWrapper = styled(Flex)`
 const ApproveAndConfirmStage: React.FC<React.PropsWithChildren<ApproveAndConfirmStageProps>> = ({
   token,
   variant,
+  gasPrice,
   isApproved,
   isApproving,
   isConfirming,
@@ -95,7 +97,7 @@ const ApproveAndConfirmStage: React.FC<React.PropsWithChildren<ApproveAndConfirm
               </Flex>
               {!vertoIsApproved && (
                 <Text small color={isApproved ? 'textSubtle' : 'textDisabled'}>
-                  {t('Please approve VERTO spending for transaction gas')}
+                  {t('Please approve %symbol% VERTO spending for transaction gas', { symbol: gasPrice })}
                 </Text>
               )}
             </Flex>


### PR DESCRIPTION
DEV-779: fix loading spinner on checkout
DEV- 781: display gas price when buying NFT

Deprecated:
<img width="398" alt="Screenshot 2024-01-04 at 6 00 09 PM" src="https://github.com/vertotrade/verto.ui/assets/46223860/71d2b4e5-b024-4067-91e1-6a7438959ba4">

UPD (with new Spinner):
<img width="444" alt="Screenshot 2024-01-09 at 11 03 29 AM" src="https://github.com/vertotrade/verto.ui/assets/46223860/a374f99d-ae90-4296-b2db-85715518e7a9">

