### PR TITLE
DEV-782: Fix "Learn how to connect" button padding

### DIFF
--- a/packages/ui-wallets/src/WalletModal.tsx
+++ b/packages/ui-wallets/src/WalletModal.tsx
@@ -164,7 +164,7 @@ function MobileModal<T>({
             {t('Haven’t got a crypto wallet yet?')}
           </Text>
         </AtomBox>
-        <Button as="a" href={docLink} variant="subtle" width="100%" external>
+        <Button as="a" href={docLink} variant="subtle" width="100%" external padding="0 15px">
           {docText}
         </Button>
       </AtomBox>
@@ -439,7 +439,7 @@ const Intro = ({ docLink, docText }: { docLink: string; docText: string }) => {
       <Heading as="h1" fontSize="20px" color="secondary">
         {t('Haven’t got a wallet yet?')}
       </Heading>
-      <Button as={LinkExternal} color="textSubtle" variant="subtle" href={docLink} hoverBackgroundColor="#27C5A2">
+      <Button as={LinkExternal} color="textSubtle" variant="subtle" href={docLink} hoverBackgroundColor="#27C5A2" padding="0 15px">
         {docText}
       </Button>
     </>


### PR DESCRIPTION
Fixed "Learn how to connect" button padding:
<img width="258" alt="Screenshot 2024-01-05 at 10 40 44 AM" src="https://github.com/vertotrade/verto.ui/assets/46223860/466f69ca-e72c-4de5-bfae-4c0634a662b8">
