### PR TITLE
feat/DEV-795 Change the color of the arrow color on Wallet drop down

### DIFF
--- a/packages/uikit/src/widgets/Menu/components/UserMenu/index.tsx
+++ b/packages/uikit/src/widgets/Menu/components/UserMenu/index.tsx
@@ -122,7 +122,7 @@ const UserMenu: React.FC<UserMenuProps> = ({
       >
         <MenuIcon className={avatarClassName} avatarSrc={avatarSrc} variant={variant} />
         <LabelText title={typeof text === "string" ? text || account : account}>{text || accountEllipsis}</LabelText>
-        {!disabled && <ChevronDownIcon color="primary" width="24px" />}
+        {!disabled && <ChevronDownIcon color="white" width="24px" />}
       </StyledUserMenu>
       {!disabled && (
         <Menu style={styles.popper} ref={setTooltipRef} {...attributes.popper} isOpen={isOpen}>


### PR DESCRIPTION
Before:
![image](https://github.com/vertotrade/verto.ui/assets/23079114/d0c22b55-81bd-4ca9-9709-f293e39784ea)
![image](https://github.com/vertotrade/verto.ui/assets/23079114/f6af0557-fbbe-45b8-a1ea-e976f45c52ea)


After:
![image](https://github.com/vertotrade/verto.ui/assets/23079114/74b0e4d0-bf18-4f39-bf4e-0a54b44c5d8e)
![image](https://github.com/vertotrade/verto.ui/assets/23079114/48fcfc4b-91d9-47b6-9038-2150eb61bf3d)
