### PR TITLE
DEV-823 Showing 2 Info links on VertoTrade header

### DIFF
--- a/apps/web/src/components/Menu/config/config.ts
+++ b/apps/web/src/components/Menu/config/config.ts
@@ -146,16 +146,6 @@ const config: (
       href: '/info',
       showItemsOnMobile: false,
     },
-    // {
-    //   label: t('Info'),
-    //   href: '/info',
-    //   showItemsOnMobile: false,
-    // },
-    {
-      label: t('Info'),
-      href: '/info',
-      showItemsOnMobile: false,
-    },
     {
       label: t('Docs'),
       href: 'https://docs.vertotrade.com',


### PR DESCRIPTION
This commit https://github.com/vertotrade/verto.ui/commit/d40417fcc1a4f57845f26da118088a12350cae08#diff-e0daeed87867fc4fc6b0b1a9c2d52c9bfbd175cd1822e100f43300c4046484ad was made months ago but wasn't merged into main until recently, so I added this change https://github.com/vertotrade/verto.ui/commit/6497b99a85bc3cdd47b19ae48c29e216800ddf6d not knowing it was already done so now we were having double info tab.
